### PR TITLE
Improve splash and tracker logic

### DIFF
--- a/CycleSyncAI/AppDelegate.swift
+++ b/CycleSyncAI/AppDelegate.swift
@@ -6,12 +6,15 @@
 //
 
 import UIKit
+import HealthKit
+import UserNotifications
 
 @main
 class AppDelegate: UIResponder, UIApplicationDelegate {
 
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
-        // Override point for customization after application launch.
+        // Nothing to do here yet; permissions are requested in LaunchViewController
+
         return true
     }
 

--- a/CycleSyncAI/LaunchViewController.swift
+++ b/CycleSyncAI/LaunchViewController.swift
@@ -1,0 +1,67 @@
+import UIKit
+
+class LaunchViewController: UIViewController {
+    let splashLabel = UILabel()
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        view.backgroundColor = .systemBackground
+
+        splashLabel.translatesAutoresizingMaskIntoConstraints = false
+        splashLabel.text = "Eat. Move. Thrive. With your Cycle.\nPowered by Perplexity’s Sonar."
+        splashLabel.numberOfLines = 2
+        splashLabel.textAlignment = .center
+        splashLabel.font = UIFont(name: "Avenir-Heavy", size: 20)
+        splashLabel.textColor = UIColor(red: 102/255, green: 51/255, blue: 153/255, alpha: 1)
+        view.addSubview(splashLabel)
+
+        NSLayoutConstraint.activate([
+            splashLabel.centerXAnchor.constraint(equalTo: view.centerXAnchor),
+            splashLabel.centerYAnchor.constraint(equalTo: view.centerYAnchor)
+        ])
+    }
+
+    override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+        DispatchQueue.main.asyncAfter(deadline: .now() + 2.0) {
+            self.requestHealthPermission()
+        }
+    }
+
+    private func requestHealthPermission() {
+        if !UserDefaults.standard.bool(forKey: "healthPermissionAsked") {
+            HealthManager.shared.requestAuthorization { _, _ in
+                DispatchQueue.main.async {
+                    UserDefaults.standard.set(true, forKey: "healthPermissionAsked")
+                    self.requestNotificationPermission()
+                }
+            }
+        } else {
+            requestNotificationPermission()
+        }
+    }
+
+    private func requestNotificationPermission() {
+        if !UserDefaults.standard.bool(forKey: "notificationPermissionAsked") {
+            UNUserNotificationCenter.current().requestAuthorization(options: [.alert, .sound, .badge]) { _, _ in
+                DispatchQueue.main.async {
+                    UserDefaults.standard.set(true, forKey: "notificationPermissionAsked")
+                    self.goToHome()
+                }
+            }
+        } else {
+            goToHome()
+        }
+    }
+
+    private func goToHome() {
+        let homepage = HomepageViewController()
+        if let sceneDelegate = UIApplication.shared.connectedScenes.first?.delegate as? SceneDelegate,
+           let window = sceneDelegate.window {
+            window.rootViewController = homepage
+            window.makeKeyAndVisible()
+        } else {
+            self.present(homepage, animated: true)
+        }
+    }
+}

--- a/CycleSyncAI/NotificationManager.swift
+++ b/CycleSyncAI/NotificationManager.swift
@@ -14,14 +14,14 @@ class NotificationManager {
     private init() {} // prevent external initialization
 
     // Call this once at app launch or when toggles are updated
-    func scheduleMorningReminderIfNeeded(filenames: [String]) {
+    func scheduleMorningReminderIfNeeded(dates: [String]) {
         let isOn = UserDefaults.standard.bool(forKey: "morningReminderEnabled")
         guard isOn else {
             print("🚫 Morning Reminder is OFF")
             return
         }
 
-        if isTodayCoveredByPlans(filenames: filenames) {
+        if isTodayCoveredByPlans(dates: dates) {
             print("✅ [MorningReminder] Plan already exists for today — no notification needed.")
             return
         }
@@ -55,50 +55,12 @@ class NotificationManager {
         }
     }
     
-    func isTodayCoveredByPlans(filenames: [String]) -> Bool {
-            let formatter = DateFormatter()
-            formatter.dateFormat = "d MMM"
-            formatter.locale = Locale(identifier: "en_US_POSIX")
-
-            let today = Calendar.current.startOfDay(for: Date())
-
-            for name in filenames {
-                let trimmed = name.trimmingCharacters(in: .whitespaces)
-
-                // Case 1: Direct date match
-                if let date = formatter.date(from: trimmed),
-                   Calendar.current.isDate(date, inSameDayAs: today) {
-                    return true
-                }
-
-                // Case 2: Range match
-                if trimmed.contains("-") {
-                    let components = trimmed.components(separatedBy: "-")
-                    if components.count == 2 {
-                        let startDay = components[0].trimmingCharacters(in: .whitespaces)
-                        let endComponent = components[1].trimmingCharacters(in: .whitespaces)
-
-                        let month = endComponent.components(separatedBy: " ").last ?? ""
-                        let endDay = endComponent.components(separatedBy: " ").first ?? ""
-
-                        let startDateStr = "\(startDay) \(month)"
-                        let endDateStr = "\(endDay) \(month)"
-
-                        if let startDate = formatter.date(from: startDateStr),
-                           let endDate = formatter.date(from: endDateStr) {
-                            let normalizedStart = Calendar.current.startOfDay(for: startDate)
-                            let normalizedEnd = Calendar.current.startOfDay(for: endDate)
-
-                            if (normalizedStart...normalizedEnd).contains(today) {
-                                return true
-                            }
-                        }
-                    }
-                }
-            }
-
-            return false
-        }
+    func isTodayCoveredByPlans(dates: [String]) -> Bool {
+        let isoFormatter = DateFormatter()
+        isoFormatter.dateFormat = "yyyy-MM-dd"
+        let todayStr = isoFormatter.string(from: Date())
+        return dates.contains { $0.trimmingCharacters(in: .whitespaces) == todayStr }
+    }
     
     func cancelMorningReminder() {
         UNUserNotificationCenter.current().removePendingNotificationRequests(withIdentifiers: ["morningReminder"])

--- a/CycleSyncAI/PlanDetailViewController.swift
+++ b/CycleSyncAI/PlanDetailViewController.swift
@@ -15,6 +15,8 @@ class PlanDetailViewController: UIViewController {
     var selectedDate: String = ""
     var dateOptions: [String] = []
     let completionProgress = UIProgressView(progressViewStyle: .default)
+    var calendarHeightConstraint: NSLayoutConstraint?
+    var mealMap: [String: [String: String]] = [:]
     
     init(plan: PlanModel) {
         self.plan = plan
@@ -35,6 +37,10 @@ class PlanDetailViewController: UIViewController {
 
         self.selectedDate = PlanDetailViewController.chooseDefaultDate(from: self.dateOptions)
         print("🔢 Date Options Extracted: \(self.dateOptions)")
+
+        if plan.type == "diet" {
+            self.mealMap = PlanDetailViewController.parseMeals(from: plan.content, dates: self.dateOptions)
+        }
 
         super.init(nibName: nil, bundle: nil)
     }
@@ -132,6 +138,7 @@ class PlanDetailViewController: UIViewController {
         self.dateButton.titleLabel?.font = UIFont(name: "Avenir", size: 16)
         self.dateButton.translatesAutoresizingMaskIntoConstraints = false
         self.dateButton.addTarget(self, action: #selector(toggleCalendar), for: .touchUpInside)
+        self.dateButton.isEnabled = dateOptions.count > 1
         contentView.addSubview(self.dateButton)
 
         // 🟦 Container to hold the calendar (for show/hide cleanly)
@@ -147,6 +154,17 @@ class PlanDetailViewController: UIViewController {
         calendarPicker.translatesAutoresizingMaskIntoConstraints = false
         calendarPicker.addTarget(self, action: #selector(calendarDatePicked(_:)), for: .valueChanged)
         calendarWrapper.addSubview(calendarPicker)
+
+        self.calendarHeightConstraint = calendarWrapper.heightAnchor.constraint(equalToConstant: 0)
+        self.calendarHeightConstraint?.isActive = true
+
+        if let first = dateOptions.first,
+           let last = dateOptions.last {
+            let iso = DateFormatter()
+            iso.dateFormat = "yyyy-MM-dd"
+            calendarPicker.minimumDate = iso.date(from: first)
+            calendarPicker.maximumDate = iso.date(from: last)
+        }
 
         NSLayoutConstraint.activate([
             label.topAnchor.constraint(equalTo: anchor, constant: 10),
@@ -250,7 +268,11 @@ class PlanDetailViewController: UIViewController {
 
             for component in componentsToTrack {
                 let checkbox = UIButton(type: .system)
-                checkbox.setTitle(component, for: .normal)
+                if let meal = self.mealMap[self.selectedDate]?[component], !meal.isEmpty {
+                    checkbox.setTitle("\(component): \(meal)", for: .normal)
+                } else {
+                    checkbox.setTitle(component, for: .normal)
+                }
                 checkbox.contentHorizontalAlignment = .left
                 checkbox.titleLabel?.font = UIFont(name: "Avenir", size: 16)
                 checkbox.tintColor = UIColor(red: 0.663, green: 0.776, blue: 1.0, alpha: 1)
@@ -266,7 +288,7 @@ class PlanDetailViewController: UIViewController {
                     checkbox.setImage(UIImage(systemName: updated ? "checkmark.square" : "square"), for: .normal)
 
                     self.updateCompletionProgress()
-                    if TrackerManager.shared.isAllComplete(for: dateForCheckbox) {
+                    if TrackerManager.shared.isAllComplete(for: dateForCheckbox, planType: self.plan.type) {
                         self.showCompletionBanner(for: dateForCheckbox)
                     }
                 }, for: .touchUpInside)
@@ -327,6 +349,44 @@ class PlanDetailViewController: UIViewController {
                 banner.removeFromSuperview()
             }
         }
+    }
+
+    // MARK: - Meal Parsing
+
+    static func parseMeals(from html: String, dates: [String]) -> [String: [String: String]] {
+        var result: [String: [String: String]] = [:]
+
+        // Grab table rows
+        guard let rowRegex = try? NSRegularExpression(pattern: "<tr>(.*?)</tr>", options: [.dotMatchesLineSeparators]) else {
+            return result
+        }
+        let nsHtml = html as NSString
+        let rowMatches = rowRegex.matches(in: html, options: [], range: NSRange(location: 0, length: nsHtml.length))
+        var dateIndex = 0
+        for match in rowMatches.dropFirst() { // drop header
+            guard dateIndex < dates.count else { break }
+            let rowContent = nsHtml.substring(with: match.range(at: 1))
+            guard let cellRegex = try? NSRegularExpression(pattern: "<td[^>]*>(.*?)</td>", options: [.dotMatchesLineSeparators]) else { continue }
+            let cellMatches = cellRegex.matches(in: rowContent, options: [], range: NSRange(location: 0, length: (rowContent as NSString).length))
+            if cellMatches.count >= 9 {
+                var map: [String: String] = [:]
+                let labels = ["Morning Drink", "Breakfast", "Mid-Morning Snack", "Lunch", "Evening Snack", "Dinner"]
+                for (i,label) in labels.enumerated() {
+                    let idx = i + 3
+                    if idx < cellMatches.count {
+                        let cell = (rowContent as NSString).substring(with: cellMatches[idx].range(at: 1))
+                        map[label] = stripHTML(from: cell)
+                    }
+                }
+                result[dates[dateIndex]] = map
+            }
+            dateIndex += 1
+        }
+        return result
+    }
+
+    static func stripHTML(from string: String) -> String {
+        return string.replacingOccurrences(of: "<[^>]+>", with: "", options: .regularExpression, range: nil).trimmingCharacters(in: .whitespacesAndNewlines)
     }
 
 
@@ -391,9 +451,12 @@ class PlanDetailViewController: UIViewController {
     }
     
     @objc func toggleCalendar() {
-        guard let container = calendarContainer else { return }
+        guard let container = calendarContainer, dateOptions.count > 1 else { return }
+        let showing = container.isHidden
+        container.isHidden.toggle()
+        calendarHeightConstraint?.constant = showing ? calendarPicker.intrinsicContentSize.height : 0
         UIView.animate(withDuration: 0.3) {
-            container.isHidden.toggle()
+            self.view.layoutIfNeeded()
         }
     }
     

--- a/CycleSyncAI/SceneDelegate.swift
+++ b/CycleSyncAI/SceneDelegate.swift
@@ -19,7 +19,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         guard let windowScene = (scene as? UIWindowScene) else { return }
 
         window = UIWindow(windowScene: windowScene)
-        let rootVC = HomepageViewController()  // or whatever your home screen is
+        let rootVC = LaunchViewController()
         window?.rootViewController = rootVC
         window?.makeKeyAndVisible()
         
@@ -37,8 +37,8 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
 
         // Morning reminder
         // ⏰ Schedule morning reminder (if needed)
-        let combinedFilenames = PlanHistoryManager.shared.getAllDateLabels()
-        NotificationManager.shared.scheduleMorningReminderIfNeeded(filenames: combinedFilenames)
+        let combinedDates = PlanHistoryManager.shared.getAllPlanDates()
+        NotificationManager.shared.scheduleMorningReminderIfNeeded(dates: combinedDates)
 
             // 🌀 Schedule phase change reminder (centralized logic)
         NotificationManager.shared.triggerPhaseReminderIfNeeded()

--- a/CycleSyncAI/SettingsViewController.swift
+++ b/CycleSyncAI/SettingsViewController.swift
@@ -155,8 +155,8 @@ class SettingsViewController: UIViewController {
 
             if trimmedKey == "morningReminderEnabled" {
                 if toggle.isOn {
-                    let combinedFilenames = PlanHistoryManager.shared.getAllDateLabels()
-                    NotificationManager.shared.scheduleMorningReminderIfNeeded(filenames: combinedFilenames)
+                    let combinedDates = PlanHistoryManager.shared.getAllPlanDates()
+                    NotificationManager.shared.scheduleMorningReminderIfNeeded(dates: combinedDates)
                 } else {
                     NotificationManager.shared.cancelMorningReminder()
                 }

--- a/CycleSyncAI/TrackerManager.swift
+++ b/CycleSyncAI/TrackerManager.swift
@@ -41,10 +41,15 @@ class TrackerManager {
         return data[date]?[component] ?? false
     }
 
-    func isAllComplete(for date: String) -> Bool {
-        let allComponents = dietComponents + workoutComponents + hydrationComponent
+    func isAllComplete(for date: String, planType: String) -> Bool {
+        let components: [String]
+        if planType == "diet" {
+            components = dietComponents + hydrationComponent
+        } else {
+            components = workoutComponents
+        }
         let dayData = loadTrackingData()[date] ?? [:]
-        for item in allComponents {
+        for item in components {
             if dayData[item] != true {
                 return false
             }


### PR DESCRIPTION
## Summary
- request HealthKit then notification permissions sequentially after the splash screen
- leave AppDelegate empty of permission prompts
- show tracker date calendar only when the user taps the date

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_6888adf116a083218b21e571dc2a4b24